### PR TITLE
Fix out-of-schedule updates being silently skipped

### DIFF
--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -814,6 +814,8 @@ condition:
   - condition: or
     conditions:
       - condition: trigger
+        id: "Backup sensor recovered"
+      - condition: trigger
         id: "Out of schedule"
       - condition: and
         conditions:

--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -22,7 +22,7 @@
 ####################################################################################################
 ---
 blueprint:
-  name: Home Assistant Auto-update on a schedule base
+  name: Home Assistant Auto-update on a schedule base v2026.5.0
   author: Edward Firmo (https://github.com/edwardtfn)
   homeassistant:
     min_version: 2025.8.0
@@ -31,7 +31,7 @@ blueprint:
 
     Update Home Assistant automatically when a new update is available.
 
-    ## v2026.3.0
+    ## v2026.5.0
 
     ## Attention:
 
@@ -805,6 +805,10 @@ trigger:
     entity_id: !input update_out_of_schedule
     from: "off"
     to: "on"
+  - id: Backup sensor recovered
+    platform: state
+    entity_id: !input run_during_backup
+    to: "idle"
 
 condition:
   - condition: or
@@ -1221,9 +1225,13 @@ action:
   - alias: Report list of updates  # Combined starting + list of updates notification
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - variables:
           log_message: >
@@ -1280,10 +1288,14 @@ action:
   - alias: Pre-update actions
     if:
       - '{{ is_there_anything_to_update }}'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
       - '{{ not is_resume_after_restart }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
     then:
       - variables:
           input_actions_pre_update: !input actions_pre_update
@@ -1304,10 +1316,13 @@ action:
   - alias: Wait for backup system to be idle  # Wait if a backup is already in progress
     if:
       - '{{ is_there_anything_to_update }}'
-      - '{{ not is_resume_after_restart }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - variables:
           input_run_during_backup: !input run_during_backup
@@ -1380,10 +1395,14 @@ action:
   - alias: Backup
     if:
       - '{{ is_there_anything_to_update }}'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
       - '{{ not is_resume_after_restart }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
     then:
       - *recalc_update_list
       - variables:
@@ -1624,9 +1643,13 @@ action:
   - alias: Update generic
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - *recalc_update_list
       - variables:
@@ -1740,9 +1763,13 @@ action:
   - alias: Devices firmware
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - *recalc_update_list
       - variables:
@@ -1795,9 +1822,13 @@ action:
   - alias: Update core
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - *recalc_update_list
       - variables:
@@ -1851,9 +1882,13 @@ action:
   - alias: Update OS
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - *recalc_update_list
       - variables:
@@ -1908,9 +1943,13 @@ action:
     continue_on_error: true
     if:
       - '{{ is_there_anything_to_update }}'
-      - condition: state
-        entity_id: !input schedule_entity
-        state: 'on'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
     then:
       - *recalc_update_list
       - variables:


### PR DESCRIPTION
## Summary

This PR fixes two related issues affecting the reliability of the automation when running outside the configured schedule window.

## Issue 1: Out-of-schedule updates were silently skipped

When an entity listed in `update_out_of_schedule` had a pending update and the schedule entity was `off`, the automation would trigger correctly (the outer `condition:` block was already aware of out-of-schedule mode), but every update block (`Update generic`, `Devices firmware`, `Update core`, `Update OS`, `Update - Remaining`) had its own `if:` condition that checked only `schedule_entity state: 'on'`.

The result: the automation would log `List of updates`, skip every install block, then report `Remaining updates` followed by `Done!` without ever calling `update.install`. From the user's side this looked like a successful run, but no install was attempted.

### Fix

In each of the five affected blocks, the per-block `if:` schedule check was changed from a hard `state: 'on'` requirement to an `or` that also accepts `is_out_of_schedule_mode`. This matches the pattern already used in the `while:` conditions inside the repeat loops, which were already correct.

Affected blocks:
- `Update generic`
- `Devices firmware`
- `Update core`
- `Update OS`
- `Update - Remaining`

The earlier blocks (`Set ON helper flag`, `Pre-update actions`, `Wait for backup system to be idle`, `Backup`) were intentionally left gated on schedule on, since out-of-schedule runs target a specific user-chosen entity and should not drag the full backup and pre-update flow with them.

## Issue 2: Automation did not retry after a backup sensor stall

When the backup state sensor failed to leave `idle` within 30 seconds, the automation correctly stopped to avoid running updates without a backup. However, no trigger existed to retry the run when the sensor later recovered, so the schedule window could pass entirely with no further attempt.

### Fix

Added a new trigger that fires when `run_during_backup` returns to `idle`. The existing condition block already covers re-entry (schedule on + pending updates), so no condition changes were needed. The `*reset_helper_flag` call on stall is preserved, which means the retry enters the Backup section fresh and attempts the backup again from scratch.

## Verification

Both fixes were verified against the trace from a real run. Before the fix, the trace showed every update block evaluating its `if:` to `False` with `state: 'off', wanted_state: 'on'` and the install service was never called. After the fix, the trace shows the `Update generic` block entering its `then:` branch, the repeat loop iterating once, `update.install` being called against the out-of-schedule entity, and the wait template completing successfully when the entity transitioned to `off`.