### PR TITLE
feat: add `minimum_patch_version` input to skip early patch releases

### DIFF
--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -1155,14 +1155,12 @@ action:
               {% endif %}
 
               {% if input_minimum_patch_version | int(0) > 0 %}
-                {% if core_latest_version and
-                      version(core_latest_version).patch | int(-1) >= 0 and
-                      version(core_latest_version).patch | int(-1) < input_minimum_patch_version | int(0) %}
+                {% set core_patch = version(core_latest_version).patch | int(-1) if core_latest_version else -1 %}
+                {% if core_patch >= 0 and core_patch < input_minimum_patch_version | int(0) %}
                   {% set exclusions = exclusions + [core_update_entity | default("")] %}
                 {% endif %}
-                {% if os_latest_version and
-                      version(os_latest_version).patch | int(-1) >= 0 and
-                      version(os_latest_version).patch | int(-1) < input_minimum_patch_version | int(0) %}
+                {% set os_patch = version(os_latest_version).patch | int(-1) if os_latest_version else -1 %}
+                {% if os_patch >= 0 and os_patch < input_minimum_patch_version | int(0) %}
                   {% set exclusions = exclusions + [os_update_entity | default("")] %}
                 {% endif %}
               {% endif %}

--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -22,7 +22,7 @@
 ####################################################################################################
 ---
 blueprint:
-  name: Home Assistant Auto-update on a schedule base v2026.5.1
+  name: Home Assistant Auto-update on a schedule base v2026.5.4
   author: Edward Firmo (https://github.com/edwardtfn)
   homeassistant:
     min_version: 2025.8.0
@@ -31,7 +31,7 @@ blueprint:
 
     Update Home Assistant automatically when a new update is available.
 
-    ## v2026.5.1
+    ## v2026.5.4
 
     ## Attention:
 
@@ -278,6 +278,30 @@ blueprint:
             entity:
               multiple: true
               domain: update
+
+        minimum_patch_version:
+          name: Minimum patch version
+          description: >
+            Minimum patch number required before an update is automatically installed.
+
+            When set to `0` (default), this filter is disabled and all updates are considered regardless of patch version.
+
+            When set to a value greater than `0`, any update entity where the latest version has a patch component
+            lower than this threshold will be skipped. This applies globally across core/OS, firmware, and general updates.
+
+            Examples:
+              - `1`: skip `x.y.0`, allow `x.y.1` and above.
+              - `2`: skip `x.y.0` and `x.y.1`, allow `x.y.2` and above.
+
+            Note: for update entities where the version is not parseable as a dotted version,
+            this check is silently skipped and the update is allowed.
+          default: 0
+          selector:
+            number:
+              min: 0
+              max: 9
+              step: 1
+              mode: slider
 
     backup_section:
       name: Backup (optional)
@@ -764,6 +788,14 @@ trigger_variables:
   input_update_inclusion_entity_searchfilter: !input update_inclusion_entity_searchfilter
   input_update_process_started_entity: !input update_process_started_entity
   update_out_of_schedule: !input update_out_of_schedule
+  installable_entities: >
+    {% set ns = namespace(list=[]) %}
+    {% for e in states.update | default([]) %}
+      {% if (e.attributes.supported_features | int(0)) | bitwise_and(1) %}
+        {% set ns.list = ns.list + [e.entity_id] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.list }}
 
 trigger:
   - id: HA Schedule based
@@ -779,7 +811,7 @@ trigger:
         states.update
         | default([])
         | selectattr("state", "eq", "on")
-        | rejectattr("attributes.supported_features", "eq", 0)
+        | selectattr("entity_id", "in", installable_entities)
         | rejectattr("entity_id", "in", input_update_exclusions)
         | rejectattr("entity_id", "in", update_out_of_schedule)
         | list | count | int(0) > 0
@@ -832,7 +864,7 @@ condition:
                 states.update
                 | default([])
                 | selectattr("state", "eq", "on")
-                | rejectattr("attributes.supported_features", "eq", 0)
+                | selectattr("entity_id", "in", installable_entities)
                 | selectattr("entity_id", "in", update_out_of_schedule)
                 | rejectattr("entity_id", "in", input_update_exclusions)
                 | list | count | int(0) > 0
@@ -848,7 +880,7 @@ condition:
                 states.update
                 | default([])
                 | selectattr("state", "eq", "on")
-                | rejectattr("attributes.supported_features", "eq", 0)
+                | selectattr("entity_id", "in", installable_entities)
                 | rejectattr("entity_id", "in", input_update_exclusions)
                 | list | count | int(0) > 0
               }}
@@ -886,6 +918,7 @@ variables:
   input_firmware_update_mode: !input firmware_update_mode
   input_general_update_mode: !input general_update_mode
   input_update_inclusion_mode: !input update_inclusion_mode
+  input_minimum_patch_version: !input minimum_patch_version
   input_notification_entity: !input notification_entity
   input_notification_select_notifications: !input notification_select_notifications
   input_notification_message_title: !input notification_message_title
@@ -918,7 +951,7 @@ variables:
           states.update
           | default([])
           | selectattr("state", "eq", "on")
-          | rejectattr("attributes.supported_features", "eq", 0)
+          | selectattr("entity_id", "in", installable_entities)
           | selectattr("entity_id", "in", update_out_of_schedule)
           | rejectattr("entity_id", "in", input_update_exclusions)
           | list | count | int(0) > 0
@@ -1120,6 +1153,19 @@ action:
                   {% set exclusions = exclusions + [os_update_entity | default("")] %}
                 {% endif %}
               {% endif %}
+
+              {% if input_minimum_patch_version | int(0) > 0 %}
+                {% if core_latest_version and
+                      version(core_latest_version).patch | int(-1) >= 0 and
+                      version(core_latest_version).patch | int(-1) < input_minimum_patch_version | int(0) %}
+                  {% set exclusions = exclusions + [core_update_entity | default("")] %}
+                {% endif %}
+                {% if os_latest_version and
+                      version(os_latest_version).patch | int(-1) >= 0 and
+                      version(os_latest_version).patch | int(-1) < input_minimum_patch_version | int(0) %}
+                  {% set exclusions = exclusions + [os_update_entity | default("")] %}
+                {% endif %}
+              {% endif %}
             {% endif %}
 
             {% if input_firmware_update_mode == 'ignore' %}
@@ -1139,6 +1185,13 @@ action:
                   {% endif %}
                 {% elif input_firmware_update_mode == 'major_and_minor' %}
                   {% if (not entity_version_change.major) and (not entity_version_change.minor) %}
+                    {% set ns.entities = ns.entities + [ entity.entity_id ] %}
+                  {% endif %}
+                {% endif %}
+                {% if input_minimum_patch_version | int(0) > 0 and
+                      entity.entity_id not in ns.entities %}
+                  {% set patch = version(entity.attributes.latest_version | default('')).patch | int(-1) %}
+                  {% if patch >= 0 and patch < input_minimum_patch_version | int(0) %}
                     {% set ns.entities = ns.entities + [ entity.entity_id ] %}
                   {% endif %}
                 {% endif %}
@@ -1163,6 +1216,13 @@ action:
                   {% endif %}
                 {% elif input_general_update_mode == 'major_and_minor' %}
                   {% if (not entity_version_change.major) and (not entity_version_change.minor) %}
+                    {% set ns.entities = ns.entities + [ entity.entity_id ] %}
+                  {% endif %}
+                {% endif %}
+                {% if input_minimum_patch_version | int(0) > 0 and
+                      entity.entity_id not in ns.entities %}
+                  {% set patch = version(entity.attributes.latest_version | default('')).patch | int(-1) %}
+                  {% if patch >= 0 and patch < input_minimum_patch_version | int(0) %}
                     {% set ns.entities = ns.entities + [ entity.entity_id ] %}
                   {% endif %}
                 {% endif %}

--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -22,7 +22,7 @@
 ####################################################################################################
 ---
 blueprint:
-  name: Home Assistant Auto-update on a schedule base v2026.5.4
+  name: Home Assistant Auto-update on a schedule base v2026.5.5
   author: Edward Firmo (https://github.com/edwardtfn)
   homeassistant:
     min_version: 2025.8.0
@@ -31,7 +31,7 @@ blueprint:
 
     Update Home Assistant automatically when a new update is available.
 
-    ## v2026.5.4
+    ## v2026.5.5
 
     ## Attention:
 
@@ -2084,7 +2084,16 @@ action:
         timeout: !input update_timeout
 
   - alias: Finishing
-    sequence:
+    if:
+      - '{{ is_there_anything_to_update }}'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
+    then:
       - *recalc_update_list
       - variables:
           log_message: "Finishing update process"
@@ -2256,7 +2265,16 @@ action:
         continue_on_error: true
 
   - alias: Done  # All done!
-    sequence:
+    if:
+      - '{{ is_there_anything_to_update }}'
+      - condition: or
+        conditions:
+          - condition: template
+            value_template: '{{ is_out_of_schedule_mode }}'
+          - condition: state
+            entity_id: !input schedule_entity
+            state: 'on'
+    then:
       - variables:
           log_message: "Done!"
       - *logbook_update


### PR DESCRIPTION
Adds a new global input `minimum_patch_version` (default: 0, disabled) to the `what_section`.

When set to a value greater than 0, any update entity whose latest version has a patch component below the threshold is excluded from automatic installation. This applies consistently across core/OS, firmware, and general update categories.

If the version of an entity is not parseable, the check is silently skipped and the update proceeds normally. This is documented in the input description.

Changes:
- Added `minimum_patch_version` number input (slider, 0-9) to `what_section`
- Added `input_minimum_patch_version` variable to the `variables` block
- Applied patch threshold exclusion in `input_update_exclusions` for core/OS
- Applied patch threshold exclusion in the firmware entity loop
- Applied patch threshold exclusion in the general entity loop

Closes edwardtfn/HomeAssistant-Config#22