### PR TITLE
fix: compute installable_entities in full template context (fixes scheduled runs)

### DIFF
--- a/auto_update_scheduled.yaml
+++ b/auto_update_scheduled.yaml
@@ -788,14 +788,6 @@ trigger_variables:
   input_update_inclusion_entity_searchfilter: !input update_inclusion_entity_searchfilter
   input_update_process_started_entity: !input update_process_started_entity
   update_out_of_schedule: !input update_out_of_schedule
-  installable_entities: >
-    {% set ns = namespace(list=[]) %}
-    {% for e in states.update | default([]) %}
-      {% if (e.attributes.supported_features | int(0)) | bitwise_and(1) %}
-        {% set ns.list = ns.list + [e.entity_id] %}
-      {% endif %}
-    {% endfor %}
-    {{ ns.list }}
 
 trigger:
   - id: HA Schedule based
@@ -807,15 +799,16 @@ trigger:
   - id: New update
     platform: template
     value_template: >-
-      {{
-        states.update
-        | default([])
-        | selectattr("state", "eq", "on")
-        | selectattr("entity_id", "in", installable_entities)
-        | rejectattr("entity_id", "in", input_update_exclusions)
-        | rejectattr("entity_id", "in", update_out_of_schedule)
-        | list | count | int(0) > 0
-      }}
+      {% set ns = namespace(found=false) %}
+      {% for e in states.update | default([])
+           | selectattr("state", "eq", "on")
+           | rejectattr("entity_id", "in", input_update_exclusions)
+           | rejectattr("entity_id", "in", update_out_of_schedule) %}
+        {% if (e.attributes.supported_features | int(0)) | bitwise_and(1) %}
+          {% set ns.found = true %}
+        {% endif %}
+      {% endfor %}
+      {{ ns.found }}
   - id: New day
     platform: template
     value_template: >
@@ -912,6 +905,14 @@ condition:
         state: 'off'
 
 variables:
+  installable_entities: >
+    {% set ns = namespace(list=[]) %}
+    {% for e in states.update | default([]) %}
+      {% if (e.attributes.supported_features | int(0)) | bitwise_and(1) %}
+        {% set ns.list = ns.list + [e.entity_id] %}
+      {% endif %}
+    {% endfor %}
+    {{ ns.list }}
   temp_input_update_exclusions: !input update_exclusions
   input_verbose_logging_bool: !input verbose_logging_bool
   input_core_os_update_mode: !input core_os_update_mode


### PR DESCRIPTION
## Problem
On HA 2026.x, scheduled runs never install anything (every run ends in `failed_conditions`) and the `New update` trigger never fires — even with a pending `update.*` entity `on`, the schedule `on`, and no pause entity active. (Reported in #14, also #15.)

## Root cause
`installable_entities` is defined in `trigger_variables:`, which HA evaluates as a **limited template** with no access to the state machine (`states`/`states.update`). It therefore always resolves to `[]`, so every `selectattr("entity_id", "in", installable_entities)` matches nothing:

- the scheduled-window / out-of-schedule **conditions** are always false → `failed_conditions`;
- `is_out_of_schedule_mode` never sees installable updates;
- the `New update` **trigger** never fires.

## Fix
- **Move** `installable_entities` from `trigger_variables:` to `variables:` (full context). The conditions and `is_out_of_schedule_mode` read it correctly there.
- **Inline** the install-capability check in the `New update` trigger's `value_template`. A `template` trigger's `value_template` already runs with full state access (and cannot read `variables:`), so it computes the filter directly.

`non_installable_entities` already lives in `variables:` and is self-contained — left unchanged. No behavior change beyond fixing the evaluation context.

## Validation (HA Core 2026.6.0)
- `states.update | count` → **0** inside `trigger_variables`, **75** in `variables:` / the Template editor — confirms the limited-template root cause.
- A same-named `variables:` value overrides the `trigger_variables` one in condition scope, so the conditions pick up the corrected list.
- A `template` trigger using `is_state(...)` (blocked in limited templates) **fired** → confirms trigger `value_template`s have full state access.
- With the fix applied, a real scheduled run passed its conditions (`installable_entities` = 60) and installed 5 device-firmware updates one-by-one with **no runaway loop**, finishing cleanly. The new `New update` expression renders correctly (`False` with nothing pending; the capability check returns `True` when an installable update exists).

Fixes #14
Related: #15
